### PR TITLE
Fix for new required hooks

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -26,7 +26,8 @@ import yaml
 
 
 # Define letsencrypt.sh defaults
-LETSENCRYPT_ROOT = '/etc/dehydrated/certs/{domain}/{pem}.pem'
+#LETSENCRYPT_ROOT = '/etc/dehydrated/certs/{domain}/{pem}.pem'
+LETSENCRYPT_ROOT = '/root/dehydrated/certs/{domain}/{pem}.pem'
 
 # Set user config file path
 CONFIG_FILE = os.path.join(

--- a/hook.py
+++ b/hook.py
@@ -150,8 +150,8 @@ def deploy_challenge(args):
         removed = remove_record(record, value)
         print ' + {0}: {1}'.format(removed['data'], removed['result'])
 
-        print ' + Settling down for 10s...'
-        time.sleep(10)
+        print ' + Settling down for 30s...'
+        time.sleep(30)
 
     # Add new record
     print ' + Adding new TXT record {0}...'.format(token)
@@ -159,13 +159,13 @@ def deploy_challenge(args):
     print ' + {0}: {1}'.format(added['data'], added['result'])
 
     # Sleep to give record time to update
-    print ' + Settling down for 10s...'
-    time.sleep(10)
+    print ' + Settling down for 30s...'
+    time.sleep(30)
 
     # Wait for the DNS change to propagate
-    while has_dns_propagated(record, token) is False:
-        print ' + DNS not propagated, waiting 30s...'
-        time.sleep(30)
+    #while has_dns_propagated(record, token) is False:
+    #    print ' + DNS not propagated, waiting 30s...'
+    #    time.sleep(30)
 
     return
 

--- a/hook.py
+++ b/hook.py
@@ -224,6 +224,20 @@ def unchanged_cert(args):
 
     return
 
+def invalid_challenge(args):
+    domain, result = args
+    msg = ' + Invalid challenge for \'{0}\''
+    print msg.format(domain)
+    msg = ' + Full error: \'{0}\''
+    print msg.format(result)
+
+    return
+
+def startup_hook(args):
+    return
+
+def exit_hook(args):
+    return
 
 def run_hook(args):
     """Determine action to take based on CLI args."""
@@ -232,7 +246,10 @@ def run_hook(args):
         'deploy_challenge': deploy_challenge,
         'clean_challenge': clean_challenge,
         'deploy_cert': deploy_cert,
-        'unchanged_cert': unchanged_cert
+        'unchanged_cert': unchanged_cert,
+        'invalid_challenge': invalid_challenge,
+        'startup_hook': startup_hook,
+        'exit_hook': exit_hook
     }
 
     # Deploy hook operation

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+apt-get install python-pip
+git clone https://github.com/lukas2511/dehydrated.git /root/dehydrated
+mkdir /root/dehydrated/hooks
+git clone https://github.com/rewardone/dehydrated-dreamhost-hook.git /root/dehydrated/hooks/dreamhost
+pip install -r /root/dehydrated/hooks/dreamhost/requirements.txt
+mkdir -p /root/.config/dehydrated
+cp /root/dehydrated/hooks/dreamhost/sample_deploy.conf /root/.config/dehydrated/deploy.conf
+echo "Please export your DREAMHOST_API_KEY with: export DREAMHOST_API_KEY='Key'"
+echo "Please update your /root/.config/dehydrated/deploy.conf file"
+
+


### PR DESCRIPTION
As detailed by [another hook](https://github.com/kappataumu/letsencrypt-cloudflare-hook/pull/38): 
'startup_hook' is required by dehydrated from commit 60583d3ef9a62712851adeb488c7b454dc36ccbf .

This fix implements the cloudflare-hook solution by adding empty return functions for startup_hook, exit_hook, and adds a log for invalid_challenge. 