### PR TITLE
Fixed to work with latest Dehydrated

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -253,9 +253,13 @@ def run_hook(args):
     }
 
     # Deploy hook operation
-    print ' + Dreamhost hook executing: {0}'.format(args[0])
-    operations[args[0]](args[1:])
-
+    if args[0] in operations:
+        print ' + Dreamhost hook executing: {0}'.format(args[0])
+        operations[args[0]](args[1:])
+    else:
+        # Per https://github.com/lukas2511/dehydrated/blob/537877a0e2fa39b16676a22aa3069730f5ba0ee4/dehydrated#L88
+        # Ignore any unknown hooks
+        pass
     return
 
 


### PR DESCRIPTION
Newer version of Dehydrated toss in an intentionally bad hook `this_hookscript_is_broken__dehydrated_is_working_fine__please_ignore_unknown_hooks_in_your_script` to ensure that scripts are halding unknown hooks properly, aka ignoring them.

It detects if it's handling it properly by testing if it outputs anything which means we need to exit normally without error on unkown hooks